### PR TITLE
Tiny change to generic-users to work with ruby 1.9

### DIFF
--- a/generic-users/recipes/default.rb
+++ b/generic-users/recipes/default.rb
@@ -25,7 +25,7 @@
 #
 
 active_groups =
-  (node[:users][:active_groups] || node[:active_groups]).to_a | node[:users][:supergroup].to_a
+  Array(node[:users][:active_groups] || node[:active_groups]) | Array(node[:users][:supergroup])
 
 log "Active groups: #{active_groups.join(', ')}" do
   level :info
@@ -85,7 +85,7 @@ active_users.each do |u|
     owner u[:username]
     group u[:gid] || u[:username]
     mode "0600"
-    variables :ssh_keys => (u['ssh_keys'].to_a | u['ssh_key'].to_a).join("\n")
+    variables :ssh_keys => (Array(u['ssh_keys']) | Array(u['ssh_key'])).join("\n")
   end
 end
 


### PR DESCRIPTION
Hello.
I've made a tiny changes that allow the cookbook to works under ruby 1.9: the .to_a method is not available anymore there, so I've changed it to Array() construction.

To be 100% honest, I've not done extensive testing (I've run the rake test, but I don't think this is covered by this), but the change is tiny and worked fine in my environment.

Thanks for your awesome cookbook: I've used it a lot a my previous employer, and I'm now starting on it at my new job :)

Benoit
