### PR TITLE
added: chef-solo-search compatibility, and ability to remove users

### DIFF
--- a/generic-users/libraries/user.rb
+++ b/generic-users/libraries/user.rb
@@ -107,9 +107,9 @@ class GenericUsers
       end
 
       # Get array of users by Chef search query on +:users+ data bag
-      def search(q)
+      def user_search(q)
         rv = []
-        Chef::Search::Query.new.search(:users, q) do |u|
+        search(:users, q) do |u|
           rv << User.new(u)
         end
         return rv


### PR DESCRIPTION
I made a few changes to make the generic-users cookbook work with chef-solo-search. I'm not sure if these will break compatibility with chef-server because I don't have an instance to test with, but they may be OK.

Also, I added support for removing users via `action:remove` attribute on user databags. This is similar to functionality in the opscode `users` cookbook.

Details:
- [generic-users/libraries/user.rb] use `Chef::Mixin::Language#search` instead of `Chef::Search::Query.new.search`, this provides compatibility with the chef-solo-search cookbook.
- [generic-users/libraries/user.rb] renamed Generic::Users#search to #user_search to avoid conflicting with Chef::Mixin::Language#search
- [generic-users/recipes/default.rb] added support for removing users that have `action:remove` attribute in their databag
