### PR TITLE
Silence Chef::Mixin::Language deprecation warnings

### DIFF
--- a/generic-users/libraries/user.rb
+++ b/generic-users/libraries/user.rb
@@ -99,7 +99,12 @@ class GenericUsers
     end
 
     class << self
-      include Chef::Mixin::Language
+      if Chef::VERSION >= '11.0.0'
+        include Chef::DSL::DataQuery
+      else
+        include Chef::Mixin::Language
+      end
+
 
       # Get user by ID
       def get(user_id)
@@ -127,7 +132,11 @@ class GenericUsers
   end
 
   class << self
-    include Chef::Mixin::Language
+    if Chef::VERSION >= '11.0.0'
+      include Chef::DSL::DataQuery
+    else
+      include Chef::Mixin::Language
+    end
 
     # Get group
     # 


### PR DESCRIPTION
Quiet the deprecation warnings for Chef::Mixin::Language on newer versions of Chef.

```
[2014-06-02T17:55:36-04:00] WARN: Chef::Mixin::Language is deprecated. Use either (or both)
Chef::DSL::PlatformIntrospection or Chef::DSL::DataQuery instead.

[2014-06-02T17:55:36-04:00] WARN: Called from:
   /var/chef/cache/cookbooks/generic-users/libraries/user.rb:102:in `singletonclass'
   /var/chef/cache/cookbooks/generic-users/libraries/user.rb:101:in `<class:User>'
   /var/chef/cache/cookbooks/generic-users/libraries/user.rb:29:in `<class:GenericUsers>'
[2014-06-02T17:55:36-04:00] WARN: Chef::Mixin::Language is deprecated. Use either (or both)
Chef::DSL::PlatformIntrospection or Chef::DSL::DataQuery instead.

[2014-06-02T17:55:36-04:00] WARN: Called from:
   /var/chef/cache/cookbooks/generic-users/libraries/user.rb:130:in `singletonclass'
   /var/chef/cache/cookbooks/generic-users/libraries/user.rb:129:in `<class:GenericUsers>'
   /var/chef/cache/cookbooks/generic-users/libraries/user.rb:26:in `<top (required)>'
```
